### PR TITLE
47 launch file for vicon

### DIFF
--- a/zoe2_bringup/launch/sandbox.launch.py
+++ b/zoe2_bringup/launch/sandbox.launch.py
@@ -1,0 +1,17 @@
+from launch import LaunchDescription
+from launch_ros.actions import Node
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.actions import IncludeLaunchDescription
+import os
+
+from ament_index_python.packages import get_package_share_directory
+
+def generate_launch_description():
+    bringup_dir = get_package_share_directory('zoe2_bringup')
+    hw_launch = os.path.join(bringup_dir, 'launch', 'hw.launch.py')
+    vicon_launch = os.path.join(bringup_dir, 'launch', 'vicon.launch.py')
+
+    return LaunchDescription([
+        IncludeLaunchDescription(PythonLaunchDescriptionSource(hw_launch)),
+        IncludeLaunchDescription(PythonLaunchDescriptionSource(vicon_launch)),
+    ])

--- a/zoe2_bringup/launch/vicon.launch.py
+++ b/zoe2_bringup/launch/vicon.launch.py
@@ -1,0 +1,22 @@
+import launch
+from launch import LaunchDescription
+from launch_ros.actions import Node
+
+def generate_launch_description():
+    return LaunchDescription([
+        Node(
+            package='vicon_bridge',
+            executable='vicon_bridge',
+            name='vicon_bridge',
+            output='screen',
+            parameters=[{'host_name': '192.168.10.1:801'}]
+        ),
+        Node(
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            name='static_transform_pub',
+            output='screen',
+            arguments=['0', '0.3', '-.47', '3.1415', '0', '0', 'vicon/morphin/morphin', 'base_link']
+            # transform between morphin's lid to zoe's base_link, centered on chassis and level with wheels
+        )
+    ])

--- a/zoe2_bringup/launch/vicon.launch.py
+++ b/zoe2_bringup/launch/vicon.launch.py
@@ -9,7 +9,8 @@ def generate_launch_description():
             executable='vicon_bridge',
             name='vicon_bridge',
             output='screen',
-            parameters=[{'host_name': '192.168.10.1:801'}]
+            parameters=[{'host_name': '192.168.10.1:801'}],
+            arguments=['--ros-args', '--log-level', 'ERROR'],
         ),
         Node(
             package='tf2_ros',


### PR DESCRIPTION
- Create `vicon.launch.py` for booting up the Vicon and publishing the transform from its frame to the base_link.
- Create `sandbox.launch.py` for booting up both HW and Vicon from one launch file 